### PR TITLE
Cloudflare cache fix

### DIFF
--- a/.github/cfp_headers
+++ b/.github/cfp_headers
@@ -25,13 +25,13 @@
   Cache-Control: no-store
 
 /i18n
-  Cache-Control: no-store
+  Cache-Control: no-cache
 
 /home
-  Cache-Control: no-store
+  Cache-Control: no-cache
 
 /sites
-  Cache-Control: no-store
+  Cache-Control: no-cache
 
 /index.html
-  Cache-Control: no-store
+  Cache-Control: no-cache

--- a/.github/cfp_headers
+++ b/.github/cfp_headers
@@ -6,9 +6,11 @@
   Content-Security-Policy: frame-ancestors 'self'
   Strict-Transport-Security: max-age=31536000; includeSubDomains; preload
   permissions-policy: accelerometer=(), gyroscope=(), magnetometer=(), usb=(), interest-cohort=()
+  Cache-Control: no-cache
 
 /version
   Content-Type: text/plain
+  Cache-Control: no-store
 
 /apple-app-site-association
   Content-Type: application/json
@@ -16,26 +18,20 @@
 /.well-known/assetlinks.json
   Content-Type: application/json
 
-/
-  Cache-Control: no-cache
-
 /config.*.json
-  Cache-Control: no-cache
+  Cache-Control: no-store
 
 /config.json
-  Cache-Control: no-cache
+  Cache-Control: no-store
 
 /i18n
-  Cache-Control: no-cache
+  Cache-Control: no-store
 
 /home
-  Cache-Control: no-cache
+  Cache-Control: no-store
 
 /sites
-  Cache-Control: no-cache
+  Cache-Control: no-store
 
 /index.html
-  Cache-Control: no-cache
-
-/version
-  Cache-Control: no-cache
+  Cache-Control: no-store


### PR DESCRIPTION
Previous builds were not able to recover after reloading the page.

`Error decrypting pickle key`
`Unable to load session Error: Error decrypting secret access_token: no pickle key found.`

This was seemingly caused by incorrect cache settings for Cloudflare pages.