### PR TITLE
Fix matrix.org registration flow

### DIFF
--- a/config.json
+++ b/config.json
@@ -52,7 +52,7 @@
         "use_exclusively": true
     },
     "default_theme": "dark",
-    "disable_3pid_login": true,
+    "disable_3pid_login": false,
     "disable_guests": true,
     "force_verification": true,
     "embedded_pages": {


### PR DESCRIPTION
As matrix.org requires an email input, which is currently disabled.