### PR TITLE
Versioning refactor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ env:
     # These must be set for fetchdep.sh to get the right branch
     REPOSITORY: ${{ github.repository }}
     PR_NUMBER: ${{ github.event.pull_request.number }}
+    COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
 permissions: {} # No permissions required
 jobs:
     build:

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
     "name": "elecord-web",
-    "version": "1.11.90",
+    "version": "2.0.1",
     "description": "Privacy focused chat app for gamers",
     "author": "hazzuk",
     "repository": {
         "type": "git",
         "url": "https://github.com/elecordapp/elecord-web"
     },
-    "license": "SEE LICENSE IN README.md",
+    "license": "AGPL-3.0-only",
     "files": [
         "lib",
         "res",

--- a/scripts/get-version-from-git.sh
+++ b/scripts/get-version-from-git.sh
@@ -6,6 +6,6 @@
 set -e
 
 # Since the deps are fetched from git, we can rev-parse
-JSSDK_SHA=$(git -C node_modules/matrix-js-sdk rev-parse --short=12 HEAD)
-VECTOR_SHA=$(git rev-parse --short=12 HEAD) # use the ACTUAL SHA rather than assume develop
+JSSDK_SHA=$(git -C node_modules/matrix-js-sdk rev-parse --short=7 HEAD)
+VECTOR_SHA=$(git rev-parse --short=7 HEAD) # use the ACTUAL SHA rather than assume develop
 echo $VECTOR_SHA-js-$JSSDK_SHA

--- a/scripts/get-version-from-git.sh
+++ b/scripts/get-version-from-git.sh
@@ -7,5 +7,6 @@ set -e
 
 # Since the deps are fetched from git, we can rev-parse
 JSSDK_SHA=$(git -C node_modules/matrix-js-sdk rev-parse --short=7 HEAD)
-VECTOR_SHA=$(git rev-parse --short=7 HEAD) # use the ACTUAL SHA rather than assume develop
-echo $VECTOR_SHA-js-$JSSDK_SHA
+#VECTOR_SHA=$(git rev-parse --short=7 HEAD) # use the ACTUAL SHA rather than assume develop
+#echo $VECTOR_SHA-js-$JSSDK_SHA
+echo "${COMMIT_SHA:0:7}-js-$JSSDK_SHA"

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-if [ -n "$DIST_VERSION" ]; then
+if [ -n "$DIST_VERSION" ] && [ "$GITHUB_REF_NAME" != "release" ]; then
     version=$DIST_VERSION
 else
     version=`git describe --dirty --tags || echo unknown`

--- a/src/components/views/auth/AuthFooter.tsx
+++ b/src/components/views/auth/AuthFooter.tsx
@@ -44,7 +44,7 @@ const AuthFooter = (): ReactElement => {
     const brandingConfig = SdkConfig.getObject("branding");
     const links = brandingConfig?.get("auth_footer_links") ?? [
         { text: "About", url: "https://elecord.app" },
-        { text: version ? `v${version}` : "Loading...", url: "https://github.com/elecordapp/elecord-web/releases" },
+        { text: version ? `${version}` : "Loading...", url: "https://github.com/elecordapp/elecord-web/releases" },
         { text: "Privacy", url: "https://github.com/elecordapp/elecord-web/blob/master/PRIVACY.md" },
         { text: "GitHub", url: "https://github.com/elecordapp/elecord-web" },
     ];

--- a/src/components/views/auth/AuthFooter.tsx
+++ b/src/components/views/auth/AuthFooter.tsx
@@ -7,16 +7,44 @@ SPDX-License-Identifier: AGPL-3.0-only OR GPL-3.0-only OR LicenseRef-Element-Com
 Please see LICENSE files in the repository root for full details.
 */
 
-import React, { ReactElement } from "react";
+import React, { ReactElement, useEffect, useState } from "react";
 
 import SdkConfig from "../../../SdkConfig";
 import { _t } from "../../../languageHandler";
 
+const fetchVersion = async (): Promise<string> => {
+    try {
+        const res = await fetch("version", {
+            method: "GET",
+            cache: "no-cache",
+        });
+        if (res.ok) {
+            const text = await res.text();
+            return text.trim().replace(/^v/, ""); // Normalize version if it starts with 'v'
+        }
+        console.error("Failed to fetch version: ", res.status);
+        return "unknown";
+    } catch (error) {
+        console.error("Error fetching version: ", error);
+        return "unknown";
+    }
+};
+
 const AuthFooter = (): ReactElement => {
+    const [version, setVersion] = useState<string>("");
+
+    useEffect(() => {
+        const loadVersion = async () => {
+            const fetchedVersion = await fetchVersion();
+            setVersion(fetchedVersion);
+        };
+        loadVersion();
+    }, []);
+
     const brandingConfig = SdkConfig.getObject("branding");
     const links = brandingConfig?.get("auth_footer_links") ?? [
         { text: "About", url: "https://elecord.app" },
-        { text: "v2.0.1", url: "https://github.com/elecordapp/elecord-web/releases" },
+        { text: version ? `v${version}` : "Loading...", url: "https://github.com/elecordapp/elecord-web/releases" },
         { text: "Privacy", url: "https://github.com/elecordapp/elecord-web/blob/master/PRIVACY.md" },
         { text: "GitHub", url: "https://github.com/elecordapp/elecord-web" },
     ];

--- a/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/HelpUserSettingsTab.tsx
@@ -64,7 +64,7 @@ export default class HelpUserSettingsTab extends React.Component<IProps, IState>
         const cryptoVersion = this.context.getCrypto()?.getVersion() ?? "<not-enabled>";
 
         return {
-            appVersion: `${_t("setting|help_about|brand_version", { brand })} 2.0.1 (${appVersion})`,
+            appVersion: `${_t("setting|help_about|brand_version", { brand })} (${appVersion})`,
             cryptoVersion: `${_t("setting|help_about|crypto_version")} ${cryptoVersion}`,
         };
     }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,7 @@ const VersionFilePlugin = require("webpack-version-file-plugin");
 
 dotenv.config();
 let ogImageUrl = process.env.RIOT_OG_IMAGE_URL;
-if (!ogImageUrl) ogImageUrl = "https://app.element.io/themes/element/img/logos/opengraph.png";
+if (!ogImageUrl) ogImageUrl = "https://web.elecord.app/themes/element/img/logos/opengraph.png";
 
 const cssThemes = {
     // CSS themes


### PR DESCRIPTION
Currently the apps versioning is partly based on element-web, and static values have to be manually updated for a release. This PR does the following to address this:

- change the `package.json` app version to elecord
- dynamically display the app version in the auth page footer
- remove elecord's static version number from settings
- shorten version numbers to 7 chars (matching github's format)
- use git tags as version on release builds
- always use the sha for the last commit made