### PR TITLE
Revert "Enable presence on matrix.org"

### DIFF
--- a/config.json
+++ b/config.json
@@ -22,8 +22,8 @@
         "servers": ["matrix.org", "gitter.im"]
     },
     "enable_presence_by_hs_url": {
-        "https://matrix.org": true,
-        "https://matrix-client.matrix.org": true
+        "https://matrix.org": false,
+        "https://matrix-client.matrix.org": false
     },
     "terms_and_conditions_links": [
         {


### PR DESCRIPTION
Reverts elecordapp/elecord-web#20

The matrix.org homeserver does not support presence, not disabling it via the config will show blank presence icons.