### PR TITLE
New theme colours

### DIFF
--- a/res/css/_common.pcss
+++ b/res/css/_common.pcss
@@ -108,6 +108,17 @@ body {
     /* see https://github.com/vector-im/element-web/issues/11425 */
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+
+    /* elecord, overwrite colour scheme */
+    --cpd-color-bg-accent-rest: var(--cpd-color-blue-900) !important;
+    --cpd-color-bg-accent-hovered: var(--cpd-color-blue-1000) !important;
+    --cpd-color-bg-accent-pressed: var(--cpd-color-blue-1100) !important;
+    --cpd-color-text-action-accent: var(--cpd-color-blue-900) !important;
+    --cpd-color-icon-accent-tertiary: var(--cpd-color-blue-800) !important;
+    --cpd-color-icon-on-solid-primary: var(--cpd-color-gray-1400) !important;
+    /* e2e verification */
+    $e2e-verified-color: var(--cpd-color-blue-900) !important;
+    $e2e-verified-color-light: var(--cpd-color-blue-300) !important;
 }
 
 pre,

--- a/res/css/_common.pcss
+++ b/res/css/_common.pcss
@@ -119,6 +119,16 @@ body {
     /* e2e verification */
     $e2e-verified-color: var(--cpd-color-blue-900) !important;
     $e2e-verified-color-light: var(--cpd-color-blue-300) !important;
+    
+    /* elecord, revert to black on-solid-primary */
+    /* share profile button */
+    .mx_ShareDialog_content > button > svg {
+        color: #101317 !important;
+    }
+    /* space invite button */
+    .mx_SpaceRoomView_landing_inviteButton:before {
+        background: #101317 !important;
+    }
 }
 
 pre,

--- a/res/css/views/right_panel/_RoomSummaryCard.pcss
+++ b/res/css/views/right_panel/_RoomSummaryCard.pcss
@@ -91,6 +91,7 @@ Please see LICENSE files in the repository root for full details.
     [data-kind="green"] {
         background: var(--cpd-color-alpha-blue-300) !important;
         color: var(--cpd-color-blue-1100) !important;
+        border: solid 1px;
     }
 }
 

--- a/res/css/views/right_panel/_RoomSummaryCard.pcss
+++ b/res/css/views/right_panel/_RoomSummaryCard.pcss
@@ -86,6 +86,12 @@ Please see LICENSE files in the repository root for full details.
 
 .mx_RoomSummaryCard_badges {
     margin: var(--cpd-space-4x) 0;
+
+    /* elecord, blue encryption badge */
+    [data-kind="green"] {
+        background: var(--cpd-color-alpha-blue-300) !important;
+        color: var(--cpd-color-blue-1100) !important;
+    }
 }
 
 .mx_RoomSummaryCard_search {

--- a/res/css/views/settings/_ThemeChoicePanel.pcss
+++ b/res/css/views/settings/_ThemeChoicePanel.pcss
@@ -20,6 +20,11 @@ Please see LICENSE files in the repository root for full details.
         gap: var(--cpd-space-2x);
         background-color: var(--cpd-color-bg-canvas-default);
 
+        /* elecord, overwrite colour scheme */
+        --cpd-color-bg-accent-rest: var(--cpd-color-blue-900) !important;
+        --cpd-color-bg-accent-hovered: var(--cpd-color-blue-1000) !important;
+        --cpd-color-bg-accent-pressed: var(--cpd-color-blue-1100) !important;
+
         &.mx_ThemeChoicePanel_themeSelector_enabled {
             border-color: var(--cpd-color-border-interactive-primary);
         }

--- a/res/themes/dark/css/_dark.pcss
+++ b/res/themes/dark/css/_dark.pcss
@@ -200,7 +200,7 @@ $voice-record-icon-color: $quaternary-content;
 
 /* Bubble tiles */
 /* ******************** */
-$eventbubble-self-bg: var(--cpd-color-green-300);
+$eventbubble-self-bg: var(--cpd-color-blue-500);
 $eventbubble-others-bg: var(--cpd-color-gray-300);
 $eventbubble-bg-hover: var(--cpd-color-bg-subtle-secondary);
 /* ******************** */

--- a/res/themes/dark/css/_dark.pcss
+++ b/res/themes/dark/css/_dark.pcss
@@ -35,20 +35,20 @@ $roomtile-default-badge-bg-color: var(--cpd-color-icon-secondary);
  * To use under very rare circumstances, always prefer the semantics defined
  * in https://compound.element.io/?path=/docs /tokens-semantic-colors--docs
  */
-$accent-100: var(--cpd-color-green-100);
-$accent-200: var(--cpd-color-green-200);
-$accent-300: var(--cpd-color-green-300);
-$accent-400: var(--cpd-color-green-400);
-$accent-500: var(--cpd-color-green-500);
-$accent-600: var(--cpd-color-green-600);
-$accent-700: var(--cpd-color-green-700);
-$accent-800: var(--cpd-color-green-800);
-$accent-900: var(--cpd-color-green-900);
-$accent-1000: var(--cpd-color-green-1000);
-$accent-1100: var(--cpd-color-green-1100);
-$accent-1200: var(--cpd-color-green-1200);
-$accent-1300: var(--cpd-color-green-1300);
-$accent-1400: var(--cpd-color-green-1400);
+$accent-100: var(--cpd-color-blue-100);
+$accent-200: var(--cpd-color-blue-200);
+$accent-300: var(--cpd-color-blue-300);
+$accent-400: var(--cpd-color-blue-400);
+$accent-500: var(--cpd-color-blue-500);
+$accent-600: var(--cpd-color-blue-600);
+$accent-700: var(--cpd-color-blue-700);
+$accent-800: var(--cpd-color-blue-800);
+$accent-900: var(--cpd-color-blue-900);
+$accent-1000: var(--cpd-color-blue-1000);
+$accent-1100: var(--cpd-color-blue-1100);
+$accent-1200: var(--cpd-color-blue-1200);
+$accent-1300: var(--cpd-color-blue-1300);
+$accent-1400: var(--cpd-color-blue-1400);
 
 /* Reused Figma non-compound colors */
 /* ******************** */

--- a/src/vector/index.html
+++ b/src/vector/index.html
@@ -21,7 +21,7 @@
     <meta name="msapplication-TileColor" content="#0fa5f6">
     <meta name="msapplication-TileImage" content="<%= require('../../res/vector-icons/mstile-150.png') %>">
     <meta name="msapplication-config" content="<%= require('../../res/vector-icons/browserconfig.xml') %>">
-    <meta name="theme-color" content="#202020">
+    <meta name="theme-color" content="#222327">
     <meta property="og:image" content="https://web.elecord.app/themes/element/img/logos/opengraph.png" />
     <meta http-equiv="Content-Security-Policy" content="
         default-src 'none';


### PR DESCRIPTION
Updates to the apps use of colours, to match elecord's blue branding.

Current implementation overwrites the compound design semantic colour tokens.

Theming by adding values to the config.json file wasn't done, so to avoid having a third 'elecord-dark' theme being presented as an option to users.

### Element reference materials

- [CPD Semantic colours](https://compound.element.io/?path=/docs/tokens-semantic-colors--docs)
- [CPD Core palette](https://compound.element.io/?path=/docs/tokens-color-palettes--docs)
- [Element-web theme guide](https://github.com/element-hq/element-web/blob/develop/docs/theming.md)