### PR TITLE
Changelog releases button

### DIFF
--- a/res/css/_components.pcss
+++ b/res/css/_components.pcss
@@ -380,6 +380,7 @@
 @import "./views/settings/tabs/user/_PreferencesUserSettingsTab.pcss";
 @import "./views/settings/tabs/user/_SecurityUserSettingsTab.pcss";
 @import "./views/settings/tabs/user/_SidebarUserSettingsTab.pcss";
+@import "./views/settings/tabs/user/_ChangelogUserSettingsTab.pcss";
 @import "./views/spaces/_SpaceBasicSettings.pcss";
 @import "./views/spaces/_SpaceChildrenPicker.pcss";
 @import "./views/spaces/_SpaceCreateMenu.pcss";

--- a/res/css/views/settings/tabs/user/_ChangelogUserSettingsTab.pcss
+++ b/res/css/views/settings/tabs/user/_ChangelogUserSettingsTab.pcss
@@ -1,0 +1,15 @@
+/*
+Copyright 2025 hazzuk.
+
+SPDX-License-Identifier: AGPL-3.0-only
+Please see LICENSE files in the repository root for full details.
+*/
+
+.mx_ChangelogDescription_buttons {
+	display: flex;
+	gap: var(--cpd-space-4x);
+	
+	svg {
+		margin-left: var(--cpd-space-2x);
+	}
+}

--- a/src/components/views/settings/tabs/user/ChangelogUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/ChangelogUserSettingsTab.tsx
@@ -18,7 +18,8 @@ import DOMPurify from "dompurify";
 import { SettingsSubsectionText } from "../../shared/SettingsSubsection";
 import SdkConfig from "../../../../../SdkConfig";
 
-const CHANGELOG_URL = "https://roadmap.elecord.app/";
+const ROADMAP_URL = "https://roadmap.elecord.app/";
+const RELEASES_URL = "https://github.com/elecordapp/elecord-web/releases";
 
 const ChangelogUserSettingsTab: React.FC = () => {
     const [changelog, setChangelog] = useState<string>("");
@@ -26,8 +27,13 @@ const ChangelogUserSettingsTab: React.FC = () => {
     const [error, setError] = useState<string | null>(null);
 
     // open external roadmap
-    const onOpenChangelog = (): void => {
-        window.open(CHANGELOG_URL, "_blank");
+    const onOpenRoadmap = (): void => {
+        window.open(ROADMAP_URL, "_blank");
+    };
+
+    // open github releases
+    const onOpenReleases = (): void => {
+        window.open(RELEASES_URL, "_blank");
     };
 
     // fetch LATEST.md changelog
@@ -67,16 +73,29 @@ const ChangelogUserSettingsTab: React.FC = () => {
     return (
         <SettingsTab>
             <SettingsSection heading={_t("settings|changelog|latest_changes")}>
+
+                {/* description */}
                 <SettingsSubsectionText>
                     {_t("settings|changelog|description", { brand: SdkConfig.get("brand") })}
                 </SettingsSubsectionText>
-                {/* roadmap button */}
-                <AccessibleButton kind="primary_outline" onClick={onOpenChangelog}>
-                    {_t("settings|changelog|roadmap")}
-                    <PopOutIcon height={20} width={20} />
-                </AccessibleButton>
+
+                {/* external links */}
+                <div className="mx_ChangelogDescription_buttons">
+                    {/* roadmap button */}
+                    <AccessibleButton kind="primary_outline" onClick={onOpenRoadmap}>
+                        {_t("settings|changelog|roadmap")}
+                        <PopOutIcon height={20} width={20} />
+                    </AccessibleButton>
+                    {/* releases button */}
+                    <AccessibleButton kind="primary_outline" onClick={onOpenReleases}>
+                        {_t("settings|changelog|releases")}
+                        <PopOutIcon height={20} width={20} />
+                    </AccessibleButton>
+                </div>
+
                 {/* render changelog */}
                 <div dangerouslySetInnerHTML={{ __html: changelog }} />
+
             </SettingsSection>
         </SettingsTab>
     );

--- a/src/components/views/settings/tabs/user/RichPresenceUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/RichPresenceUserSettingsTab.tsx
@@ -51,7 +51,7 @@ const RichPresenceUserSettingsTab: React.FC = () => {
                 {/* download button */}
                 <AccessibleButton kind="primary_outline" onClick={onDownloadClick}>
                     {_t("settings|rich_presence|download_button")}
-                    <PopOutIcon height={20} width={20} />
+                    <PopOutIcon height={20} width={20} style={{ marginLeft: "var(--cpd-space-2x)" }}/>
                 </AccessibleButton>
 
                 {/* detection notice */}

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2469,6 +2469,7 @@
             "latest_changes": "Latest changes",
             "loading_changelog": "Loading changelog…",
             "roadmap": "Roadmap",
+            "releases": "Release history",
             "description": "Read about %(brand)s's latest new features and bug fixes here. Or see what's coming next by checking out the roadmap."
         },
         "code_block_expand_default": "Expand code blocks by default",


### PR DESCRIPTION
Adds an additional button to the changelog page (inside the settings menu), as a direct link the projects [GitHub releases](https://github.com/elecordapp/elecord-web/releases).

![settings-changelog](https://github.com/user-attachments/assets/553fe158-b697-4d58-adcd-0423fe6f73ac)

Then from this change, refactors/fixes for existing settings page buttons added by elecord.