### PR TITLE
Update Element static HTML pages

### DIFF
--- a/src/vector/mobile_guide/index.html
+++ b/src/vector/mobile_guide/index.html
@@ -97,7 +97,7 @@
             }
 
             .mx_FooterLink {
-                color: #0dbd8b;
+                color: #4187eb;
                 text-decoration: none;
             }
 
@@ -146,34 +146,41 @@
         <div class="mx_HomePage_container">
             <div class="mx_HomePage_header">
                 <span class="mx_HomePage_logo">
-                    <svg width="34" height="42" viewBox="0 0 34 42" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <path
-                            fill-rule="evenodd"
-                            clip-rule="evenodd"
-                            d="M13.08 8.68C13.08 7.75216 13.8321 7 14.76 7C20.9456 7 25.96 12.0144 25.96 18.2C25.96 19.1278 25.2078 19.88 24.28 19.88C23.3521 19.88 22.6 19.1278 22.6 18.2C22.6 13.8701 19.0899 10.36 14.76 10.36C13.8321 10.36 13.08 9.60784 13.08 8.68Z"
-                            fill="#0DBD8B"
-                        />
-                        <path
-                            fill-rule="evenodd"
-                            clip-rule="evenodd"
-                            d="M20.92 33.32C20.92 34.2478 20.1679 35 19.24 35C13.0544 35 8.04001 29.9856 8.04001 23.8C8.04001 22.8722 8.79217 22.12 9.72001 22.12C10.6478 22.12 11.4 22.8722 11.4 23.8C11.4 28.1299 14.9101 31.64 19.24 31.64C20.1679 31.64 20.92 32.3922 20.92 33.32Z"
-                            fill="#0DBD8B"
-                        />
-                        <path
-                            fill-rule="evenodd"
-                            clip-rule="evenodd"
-                            d="M4.68 24.9199C3.75216 24.9199 3 24.1678 3 23.2399C3 17.0543 8.01441 12.0399 14.2 12.0399C15.1278 12.0399 15.88 12.7921 15.88 13.7199C15.88 14.6478 15.1278 15.3999 14.2 15.3999C9.87009 15.3999 6.36 18.91 6.36 23.2399C6.36 24.1678 5.60784 24.9199 4.68 24.9199Z"
-                            fill="#0DBD8B"
-                        />
-                        <path
-                            fill-rule="evenodd"
-                            clip-rule="evenodd"
-                            d="M29.32 17.0801C30.2478 17.0801 31 17.8322 31 18.7601C31 24.9457 25.9856 29.9601 19.8 29.9601C18.8722 29.9601 18.12 29.2079 18.12 28.2801C18.12 27.3522 18.8722 26.6001 19.8 26.6001C24.1299 26.6001 27.64 23.09 27.64 18.7601C27.64 17.8322 28.3922 17.0801 29.32 17.0801Z"
-                            fill="#0DBD8B"
-                        />
+                    <svg width="32" height="32" viewBox="0 0 512 512" version="1.1" id="svg1" xml:space="preserve"
+                        xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg"
+                        xmlns:svg="http://www.w3.org/2000/svg">
+                        <defs id="defs1">
+                            <linearGradient id="linearGradient40">
+                                <stop style="stop-color:#14b6f9;stop-opacity:1;" offset="0" id="stop41" />
+                                <stop style="stop-color:#0fa5f6;stop-opacity:1;" offset="0.25247523" id="stop129" />
+                                <stop style="stop-color:#106bf2;stop-opacity:1;" offset="0.69059408" id="stop130" />
+                                <stop style="stop-color:#125bed;stop-opacity:1;" offset="1" id="stop42" />
+                            </linearGradient>
+                            <linearGradient xlink:href="#linearGradient40" id="linearGradient42" x1="256" y1="0" x2="256"
+                                y2="512" gradientUnits="userSpaceOnUse" />
+                            <filter style="color-interpolation-filters:sRGB" id="filter127" x="-0.12352941" y="-0.11830986"
+                                width="1.2470587" height="1.2823944">
+                                <feFlood result="flood" in="SourceGraphic" flood-opacity="0.250980" flood-color="rgb(0,0,0)"
+                                    id="feFlood126" />
+                                <feGaussianBlur result="blur" in="SourceGraphic" stdDeviation="14.000000"
+                                    id="feGaussianBlur126" />
+                                <feOffset result="offset" in="blur" dx="0.000000" dy="13.000000" id="feOffset126" />
+                                <feComposite result="comp1" operator="in" in="flood" in2="offset" id="feComposite126" />
+                                <feComposite result="comp2" operator="over" in="SourceGraphic" in2="comp1"
+                                    id="feComposite127" />
+                            </filter>
+                        </defs>
+                        <g id="layer2" style="display:inline">
+                            <path id="path1" style="display:inline;fill:url(#linearGradient42);stroke-width:0.952441"
+                                d="M 512,256 A 256,256 0 0 1 256,512 256,256 0 0 1 0,256 256,256 0 0 1 256,0 256,256 0 0 1 512,256 Z" />
+                            <path
+                                d="m 212,116 c -50.96657,0 -92,41.03343 -92,92 v 44 c 0,35.95235 20.43219,66.94046 50.35156,82.08984 C 172.06539,368.97927 144,400 144,400 c 0,0 65.17196,-16.37821 83.33008,-52.07617 9.21713,0.71911 18.90637,1.09073 28.66992,1.09961 9.76355,-0.009 19.45279,-0.3805 28.66992,-1.09961 C 302.82826,383.62222 368,400 368,400 368,400 339.93459,368.97969 341.64844,334.08984 371.56781,318.94046 392,287.95235 392,252 v -44 c 0,-50.96657 -41.03343,-92 -92,-92 z m -26.5,86 A 25.5,25.5 0 0 1 211,227.5 25.5,25.5 0 0 1 185.5,253 25.5,25.5 0 0 1 160,227.5 25.5,25.5 0 0 1 185.5,202 Z m 141,0 A 25.5,25.5 0 0 1 352,227.5 25.5,25.5 0 0 1 326.5,253 25.5,25.5 0 0 1 301,227.5 25.5,25.5 0 0 1 326.5,202 Z m -94.2168,58.48242 c 0.0796,-0.003 0.15938,-0.003 0.23828,0 0.98224,0.0423 1.89985,0.58257 2.47852,1.51758 2.57763,4.16492 6.8405,8.6982 21,8.7168 14.15956,-0.0186 18.42236,-4.55186 21,-8.7168 1.32267,-2.13717 4.41914,-2.207 6,1 0.46425,0.9418 0.71011,1.88241 0.76367,2.81445 -0.0312,1.07703 -0.22014,2.14995 -0.56445,3.20508 C 280.54783,277.15632 269.18337,282.998 256,283 c -0.44988,-0.012 -0.89924,-0.0308 -1.34766,-0.0566 -0.14199,-0.005 -0.28393,-0.0106 -0.42578,-0.0176 -12.14078,-0.49675 -22.35549,-5.9144 -25.20312,-13.36719 -0.48257,-1.25665 -0.74259,-2.54319 -0.77539,-3.83593 0.064,-0.90207 0.30292,-1.81173 0.75195,-2.72266 0.83365,-1.69119 2.08893,-2.47138 3.2832,-2.51758 z"
+                                style="display:inline;fill:#ffffff;fill-opacity:1;stroke-width:1.08557;filter:url(#filter127)"
+                                id="path11" />
+                        </g>
                     </svg>
                 </span>
-                <p>Access elecord on iOS or Android</p>
+                <h1>Access elecord on iOS or Android</h1>
             </div>
             <div class="mx_HomePage_col">
                 <div class="mx_HomePage_row">
@@ -181,7 +188,7 @@
                         <!-- <h2 id="step1_heading">Apps</h2> -->
                         <!-- by default, conent is modified/added in index.ts -->
                         <h2>Apps</h2>
-                        <p>Elecord isn't available on mobile. Instead you can install mobile apps provided by <a href="https://element.io">Element</a>:</p>
+                        <p>While elecord isn't available on mobile. You can install mobile apps provided by <a href="https://element.io">Element</a>:</p>
                         <div class="mx_Spacer"></div>
                         <p><strong>iOS</strong> (iPhone or iPad)</p>
                         <a

--- a/src/vector/static/incompatible-browser.html
+++ b/src/vector/static/incompatible-browser.html
@@ -1,6 +1,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
 <head>
+    <title>Unsupported browser</title>
     <style type="text/css">
         /* By default, hide the custom IS stuff - enabled in JS */
         #custom_is,
@@ -88,7 +89,7 @@
         }
 
         .mx_FooterLink {
-            color: #0dbd8b;
+            color: #4187eb;
             text-decoration: none;
         }
 
@@ -135,31 +136,38 @@
     <div class="mx_HomePage_container">
         <div class="mx_HomePage_header">
             <span class="mx_HomePage_logo">
-                <svg width="34" height="42" viewBox="0 0 34 42" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path
-                        fill-rule="evenodd"
-                        clip-rule="evenodd"
-                        d="M13.08 8.68C13.08 7.75216 13.8321 7 14.76 7C20.9456 7 25.96 12.0144 25.96 18.2C25.96 19.1278 25.2078 19.88 24.28 19.88C23.3521 19.88 22.6 19.1278 22.6 18.2C22.6 13.8701 19.0899 10.36 14.76 10.36C13.8321 10.36 13.08 9.60784 13.08 8.68Z"
-                        fill="#0DBD8B"
-                    />
-                    <path
-                        fill-rule="evenodd"
-                        clip-rule="evenodd"
-                        d="M20.92 33.32C20.92 34.2478 20.1679 35 19.24 35C13.0544 35 8.04001 29.9856 8.04001 23.8C8.04001 22.8722 8.79217 22.12 9.72001 22.12C10.6478 22.12 11.4 22.8722 11.4 23.8C11.4 28.1299 14.9101 31.64 19.24 31.64C20.1679 31.64 20.92 32.3922 20.92 33.32Z"
-                        fill="#0DBD8B"
-                    />
-                    <path
-                        fill-rule="evenodd"
-                        clip-rule="evenodd"
-                        d="M4.68 24.9199C3.75216 24.9199 3 24.1678 3 23.2399C3 17.0543 8.01441 12.0399 14.2 12.0399C15.1278 12.0399 15.88 12.7921 15.88 13.7199C15.88 14.6478 15.1278 15.3999 14.2 15.3999C9.87009 15.3999 6.36 18.91 6.36 23.2399C6.36 24.1678 5.60784 24.9199 4.68 24.9199Z"
-                        fill="#0DBD8B"
-                    />
-                    <path
-                        fill-rule="evenodd"
-                        clip-rule="evenodd"
-                        d="M29.32 17.0801C30.2478 17.0801 31 17.8322 31 18.7601C31 24.9457 25.9856 29.9601 19.8 29.9601C18.8722 29.9601 18.12 29.2079 18.12 28.2801C18.12 27.3522 18.8722 26.6001 19.8 26.6001C24.1299 26.6001 27.64 23.09 27.64 18.7601C27.64 17.8322 28.3922 17.0801 29.32 17.0801Z"
-                        fill="#0DBD8B"
-                    />
+                <svg width="32" height="32" viewBox="0 0 512 512" version="1.1" id="svg1" xml:space="preserve"
+                    xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg"
+                    xmlns:svg="http://www.w3.org/2000/svg">
+                    <defs id="defs1">
+                        <linearGradient id="linearGradient40">
+                            <stop style="stop-color:#14b6f9;stop-opacity:1;" offset="0" id="stop41" />
+                            <stop style="stop-color:#0fa5f6;stop-opacity:1;" offset="0.25247523" id="stop129" />
+                            <stop style="stop-color:#106bf2;stop-opacity:1;" offset="0.69059408" id="stop130" />
+                            <stop style="stop-color:#125bed;stop-opacity:1;" offset="1" id="stop42" />
+                        </linearGradient>
+                        <linearGradient xlink:href="#linearGradient40" id="linearGradient42" x1="256" y1="0" x2="256"
+                            y2="512" gradientUnits="userSpaceOnUse" />
+                        <filter style="color-interpolation-filters:sRGB" id="filter127" x="-0.12352941" y="-0.11830986"
+                            width="1.2470587" height="1.2823944">
+                            <feFlood result="flood" in="SourceGraphic" flood-opacity="0.250980" flood-color="rgb(0,0,0)"
+                                id="feFlood126" />
+                            <feGaussianBlur result="blur" in="SourceGraphic" stdDeviation="14.000000"
+                                id="feGaussianBlur126" />
+                            <feOffset result="offset" in="blur" dx="0.000000" dy="13.000000" id="feOffset126" />
+                            <feComposite result="comp1" operator="in" in="flood" in2="offset" id="feComposite126" />
+                            <feComposite result="comp2" operator="over" in="SourceGraphic" in2="comp1"
+                                id="feComposite127" />
+                        </filter>
+                    </defs>
+                    <g id="layer2" style="display:inline">
+                        <path id="path1" style="display:inline;fill:url(#linearGradient42);stroke-width:0.952441"
+                            d="M 512,256 A 256,256 0 0 1 256,512 256,256 0 0 1 0,256 256,256 0 0 1 256,0 256,256 0 0 1 512,256 Z" />
+                        <path
+                            d="m 212,116 c -50.96657,0 -92,41.03343 -92,92 v 44 c 0,35.95235 20.43219,66.94046 50.35156,82.08984 C 172.06539,368.97927 144,400 144,400 c 0,0 65.17196,-16.37821 83.33008,-52.07617 9.21713,0.71911 18.90637,1.09073 28.66992,1.09961 9.76355,-0.009 19.45279,-0.3805 28.66992,-1.09961 C 302.82826,383.62222 368,400 368,400 368,400 339.93459,368.97969 341.64844,334.08984 371.56781,318.94046 392,287.95235 392,252 v -44 c 0,-50.96657 -41.03343,-92 -92,-92 z m -26.5,86 A 25.5,25.5 0 0 1 211,227.5 25.5,25.5 0 0 1 185.5,253 25.5,25.5 0 0 1 160,227.5 25.5,25.5 0 0 1 185.5,202 Z m 141,0 A 25.5,25.5 0 0 1 352,227.5 25.5,25.5 0 0 1 326.5,253 25.5,25.5 0 0 1 301,227.5 25.5,25.5 0 0 1 326.5,202 Z m -94.2168,58.48242 c 0.0796,-0.003 0.15938,-0.003 0.23828,0 0.98224,0.0423 1.89985,0.58257 2.47852,1.51758 2.57763,4.16492 6.8405,8.6982 21,8.7168 14.15956,-0.0186 18.42236,-4.55186 21,-8.7168 1.32267,-2.13717 4.41914,-2.207 6,1 0.46425,0.9418 0.71011,1.88241 0.76367,2.81445 -0.0312,1.07703 -0.22014,2.14995 -0.56445,3.20508 C 280.54783,277.15632 269.18337,282.998 256,283 c -0.44988,-0.012 -0.89924,-0.0308 -1.34766,-0.0566 -0.14199,-0.005 -0.28393,-0.0106 -0.42578,-0.0176 -12.14078,-0.49675 -22.35549,-5.9144 -25.20312,-13.36719 -0.48257,-1.25665 -0.74259,-2.54319 -0.77539,-3.83593 0.064,-0.90207 0.30292,-1.81173 0.75195,-2.72266 0.83365,-1.69119 2.08893,-2.47138 3.2832,-2.51758 z"
+                            style="display:inline;fill:#ffffff;fill-opacity:1;stroke-width:1.08557;filter:url(#filter127)"
+                            id="path11" />
+                    </g>
                 </svg>
             </span>
             <h1>Unsupported browser</h1>
@@ -167,9 +175,9 @@
         <div class="mx_HomePage_col">
             <div class="mx_HomePage_row">
                 <div>
-                    <h2 id="step1_heading">Your browser can't run Element</h2>
+                    <h2 id="step1_heading">Your browser can't run elecord</h2>
                     <p>
-                        Element uses many advanced browser features, some of which are not available or experimental in
+                        Sorry, elecord uses many advanced browser features, some of which are not available or experimental in
                         your current browser.
                     </p>
                     <p>
@@ -183,9 +191,10 @@
         <div class="mx_HomePage_col">
             <div class="mx_HomePage_row">
                 <div>
-                    <h2 id="step2_heading">Use Element on mobile</h2>
+                    <h2 id="step2_heading">Access on mobile</h2>
+                    <p>While elecord isn't available on mobile. You can install mobile apps provided by <a href="https://element.io">Element</a>:</p>
                     <p><strong>iOS</strong> (iPhone or iPad)</p>
-                    <a href="https://apps.apple.com/app/vector/id1083446067" target="_blank" class="mx_ClearDecoration">
+                    <a href="https://apps.apple.com/app/element-x-secure-chat-call/id1631335820" target="_blank" class="mx_ClearDecoration">
                         <svg
                             width="144px"
                             height="48px"
@@ -320,7 +329,7 @@
                     </a>
                     <p class="mx_Spacer"><strong>Android</strong></p>
                     <a
-                        href="https://play.google.com/store/apps/details?id=im.vector.app"
+                        href="https://play.google.com/store/apps/details?id=io.element.android.x"
                         target="_blank"
                         class="mx_ClearDecoration"
                     >
@@ -456,7 +465,7 @@
                         </svg>
                     </a>
                     <a
-                        href="https://f-droid.org/repository/browse/?fdid=im.vector.app"
+                        href="https://f-droid.org/packages/io.element.android.x/"
                         target="_blank"
                         class="mx_ClearDecoration"
                     >
@@ -769,7 +778,7 @@
         </div>
         <div class="mx_HomePage_row mx_Center mx_Spacer">
             <p class="mx_Spacer">
-                <a href="https://element.io" target="_blank" class="mx_FooterLink"> Go to element.io </a>
+                <a href="https://elecord.app" target="_blank" class="mx_FooterLink"> Go to www.elecord.app </a>
             </p>
         </div>
     </div>

--- a/src/vector/static/unable-to-load.html
+++ b/src/vector/static/unable-to-load.html
@@ -1,6 +1,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
 <head>
+    <title>Unable to load</title>
     <style type="text/css">
         /* By default, hide the custom IS stuff - enabled in JS */
         #custom_is,
@@ -149,31 +150,38 @@
     <div class="mx_HomePage_container">
         <div class="mx_HomePage_header">
             <span class="mx_HomePage_logo">
-                <svg width="34" height="42" viewBox="0 0 34 42" fill="none" xmlns="http://www.w3.org/2000/svg">
-                    <path
-                        fill-rule="evenodd"
-                        clip-rule="evenodd"
-                        d="M13.08 8.68C13.08 7.75216 13.8321 7 14.76 7C20.9456 7 25.96 12.0144 25.96 18.2C25.96 19.1278 25.2078 19.88 24.28 19.88C23.3521 19.88 22.6 19.1278 22.6 18.2C22.6 13.8701 19.0899 10.36 14.76 10.36C13.8321 10.36 13.08 9.60784 13.08 8.68Z"
-                        fill="#0DBD8B"
-                    />
-                    <path
-                        fill-rule="evenodd"
-                        clip-rule="evenodd"
-                        d="M20.92 33.32C20.92 34.2478 20.1679 35 19.24 35C13.0544 35 8.04001 29.9856 8.04001 23.8C8.04001 22.8722 8.79217 22.12 9.72001 22.12C10.6478 22.12 11.4 22.8722 11.4 23.8C11.4 28.1299 14.9101 31.64 19.24 31.64C20.1679 31.64 20.92 32.3922 20.92 33.32Z"
-                        fill="#0DBD8B"
-                    />
-                    <path
-                        fill-rule="evenodd"
-                        clip-rule="evenodd"
-                        d="M4.68 24.9199C3.75216 24.9199 3 24.1678 3 23.2399C3 17.0543 8.01441 12.0399 14.2 12.0399C15.1278 12.0399 15.88 12.7921 15.88 13.7199C15.88 14.6478 15.1278 15.3999 14.2 15.3999C9.87009 15.3999 6.36 18.91 6.36 23.2399C6.36 24.1678 5.60784 24.9199 4.68 24.9199Z"
-                        fill="#0DBD8B"
-                    />
-                    <path
-                        fill-rule="evenodd"
-                        clip-rule="evenodd"
-                        d="M29.32 17.0801C30.2478 17.0801 31 17.8322 31 18.7601C31 24.9457 25.9856 29.9601 19.8 29.9601C18.8722 29.9601 18.12 29.2079 18.12 28.2801C18.12 27.3522 18.8722 26.6001 19.8 26.6001C24.1299 26.6001 27.64 23.09 27.64 18.7601C27.64 17.8322 28.3922 17.0801 29.32 17.0801Z"
-                        fill="#0DBD8B"
-                    />
+                <svg width="32" height="32" viewBox="0 0 512 512" version="1.1" id="svg1" xml:space="preserve"
+                    xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2000/svg"
+                    xmlns:svg="http://www.w3.org/2000/svg">
+                    <defs id="defs1">
+                        <linearGradient id="linearGradient40">
+                            <stop style="stop-color:#14b6f9;stop-opacity:1;" offset="0" id="stop41" />
+                            <stop style="stop-color:#0fa5f6;stop-opacity:1;" offset="0.25247523" id="stop129" />
+                            <stop style="stop-color:#106bf2;stop-opacity:1;" offset="0.69059408" id="stop130" />
+                            <stop style="stop-color:#125bed;stop-opacity:1;" offset="1" id="stop42" />
+                        </linearGradient>
+                        <linearGradient xlink:href="#linearGradient40" id="linearGradient42" x1="256" y1="0" x2="256"
+                            y2="512" gradientUnits="userSpaceOnUse" />
+                        <filter style="color-interpolation-filters:sRGB" id="filter127" x="-0.12352941" y="-0.11830986"
+                            width="1.2470587" height="1.2823944">
+                            <feFlood result="flood" in="SourceGraphic" flood-opacity="0.250980" flood-color="rgb(0,0,0)"
+                                id="feFlood126" />
+                            <feGaussianBlur result="blur" in="SourceGraphic" stdDeviation="14.000000"
+                                id="feGaussianBlur126" />
+                            <feOffset result="offset" in="blur" dx="0.000000" dy="13.000000" id="feOffset126" />
+                            <feComposite result="comp1" operator="in" in="flood" in2="offset" id="feComposite126" />
+                            <feComposite result="comp2" operator="over" in="SourceGraphic" in2="comp1"
+                                id="feComposite127" />
+                        </filter>
+                    </defs>
+                    <g id="layer2" style="display:inline">
+                        <path id="path1" style="display:inline;fill:url(#linearGradient42);stroke-width:0.952441"
+                            d="M 512,256 A 256,256 0 0 1 256,512 256,256 0 0 1 0,256 256,256 0 0 1 256,0 256,256 0 0 1 512,256 Z" />
+                        <path
+                            d="m 212,116 c -50.96657,0 -92,41.03343 -92,92 v 44 c 0,35.95235 20.43219,66.94046 50.35156,82.08984 C 172.06539,368.97927 144,400 144,400 c 0,0 65.17196,-16.37821 83.33008,-52.07617 9.21713,0.71911 18.90637,1.09073 28.66992,1.09961 9.76355,-0.009 19.45279,-0.3805 28.66992,-1.09961 C 302.82826,383.62222 368,400 368,400 368,400 339.93459,368.97969 341.64844,334.08984 371.56781,318.94046 392,287.95235 392,252 v -44 c 0,-50.96657 -41.03343,-92 -92,-92 z m -26.5,86 A 25.5,25.5 0 0 1 211,227.5 25.5,25.5 0 0 1 185.5,253 25.5,25.5 0 0 1 160,227.5 25.5,25.5 0 0 1 185.5,202 Z m 141,0 A 25.5,25.5 0 0 1 352,227.5 25.5,25.5 0 0 1 326.5,253 25.5,25.5 0 0 1 301,227.5 25.5,25.5 0 0 1 326.5,202 Z m -94.2168,58.48242 c 0.0796,-0.003 0.15938,-0.003 0.23828,0 0.98224,0.0423 1.89985,0.58257 2.47852,1.51758 2.57763,4.16492 6.8405,8.6982 21,8.7168 14.15956,-0.0186 18.42236,-4.55186 21,-8.7168 1.32267,-2.13717 4.41914,-2.207 6,1 0.46425,0.9418 0.71011,1.88241 0.76367,2.81445 -0.0312,1.07703 -0.22014,2.14995 -0.56445,3.20508 C 280.54783,277.15632 269.18337,282.998 256,283 c -0.44988,-0.012 -0.89924,-0.0308 -1.34766,-0.0566 -0.14199,-0.005 -0.28393,-0.0106 -0.42578,-0.0176 -12.14078,-0.49675 -22.35549,-5.9144 -25.20312,-13.36719 -0.48257,-1.25665 -0.74259,-2.54319 -0.77539,-3.83593 0.064,-0.90207 0.30292,-1.81173 0.75195,-2.72266 0.83365,-1.69119 2.08893,-2.47138 3.2832,-2.51758 z"
+                            style="display:inline;fill:#ffffff;fill-opacity:1;stroke-width:1.08557;filter:url(#filter127)"
+                            id="path11" />
+                    </g>
                 </svg>
             </span>
             <h1>Unable to load</h1>
@@ -181,14 +189,14 @@
         <div class="mx_HomePage_col">
             <div class="mx_HomePage_row">
                 <div>
-                    <h2 id="step1_heading">Element can't load</h2>
-                    <p>Something went wrong and Element was unable to load.</p>
+                    <h2 id="step1_heading">Whoops, elecord can't load</h2>
+                    <p>Something went wrong and elecord was unable to load.</p>
                 </div>
             </div>
         </div>
         <div class="mx_HomePage_row mx_Center mx_Spacer">
             <p class="mx_Spacer">
-                <a href="https://element.io" target="_blank" class="mx_FooterLink"> Go to element.io </a>
+                <a href="https://elecord.app" target="_blank" class="mx_FooterLink"> Go to www.elecord.app </a>
             </p>
         </div>
     </div>


### PR DESCRIPTION
Switches Element's static HTML pages to use elecord's branding, relevant wording and new links:

## mobile_guide/index.html

![127 0 0 1_3000_src_vector_mobile_guide_index html](https://github.com/user-attachments/assets/bd782bd2-f610-4b6a-afb8-632cb05422c7)

## static/incompatible-browser.html

![127 0 0 1_3000_src_vector_static_incompatible-browser html](https://github.com/user-attachments/assets/460cb6d9-cb7e-4e0b-b5d3-496b8a9aaed4)

## static/unable-to-load.html

![127 0 0 1_3000_src_vector_static_unable-to-load html](https://github.com/user-attachments/assets/89eb3ef3-c7a8-45b2-97db-fd05616c5ddc)
